### PR TITLE
Correct spelling of __PRESSURE macro

### DIFF
--- a/SeeedTouchScreen.cpp
+++ b/SeeedTouchScreen.cpp
@@ -176,7 +176,7 @@ Point TouchScreen::getPoint(void) {
     }
 
 #if TSDEBUG
-    if(z > __PRESURE){
+    if(z > __PRESSURE){
         Serial.print("x1 = "); Serial.print(xx[0]);
         Serial.print("\tx2 = ");Serial.print(xx[1]);
         Serial.print("\ty2 = ");Serial.print(yy[0]);
@@ -190,6 +190,6 @@ Point TouchScreen::getPoint(void) {
 bool TouchScreen::isTouching(void)
 {
     Point p = getPoint();
-    if(p.z > __PRESURE)return 1;
+    if(p.z > __PRESSURE)return 1;
     else return 0;
 }

--- a/SeeedTouchScreen.h
+++ b/SeeedTouchScreen.h
@@ -4,7 +4,8 @@
   (c) ladyada / adafruit
   Code under MIT License.
 */
-#define __PRESURE 10
+#define __PRESSURE 10
+#define __PRESURE __PRESSURE    // Previous misspelled macro left for backwards compatibility
 class Point {
     public:
     int x, y, z;

--- a/examples/touchScreen/touchScreen.ino
+++ b/examples/touchScreen/touchScreen.ino
@@ -46,7 +46,7 @@ void loop(void) {
   // a point object holds x y and z coordinates
   Point p = ts.getPoint();
 
-  if (p.z > __PRESURE) {
+  if (p.z > __PRESSURE) {
      Serial.print("Raw X = "); Serial.print(p.x);
      Serial.print("\tRaw Y = "); Serial.print(p.y);
      Serial.print("\tPressure = "); Serial.println(p.z);
@@ -58,7 +58,7 @@ void loop(void) {
   
   // we have some minimum pressure we consider 'valid'
   // pressure of 0 means no pressing!
-  if (p.z > __PRESURE) {
+  if (p.z > __PRESSURE) {
      Serial.print("X = "); Serial.print(p.x);
      Serial.print("\tY = "); Serial.print(p.y);
      Serial.print("\tPressure = "); Serial.println(p.z);

--- a/keywords.txt
+++ b/keywords.txt
@@ -18,4 +18,4 @@ getPoint	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
-__PRESURE	LITERAL1
+__PRESSURE	LITERAL1


### PR DESCRIPTION
It was previously misspelled `__PRESURE`. I have left the previous macro defined for backwards compatibility.